### PR TITLE
Gen receiving addy

### DIFF
--- a/server/src/handler/wallet_handler.rs
+++ b/server/src/handler/wallet_handler.rs
@@ -1,14 +1,14 @@
 use crate::model::wallet_model::{WalletRequest, WalletResponse, WalletStore};
 use axum::Json;
+use axum::extract::{Path, State};
 use axum::response::IntoResponse;
-use axum::extract::{State, Path};
 use bdk::bitcoin::Network;
 use bdk::database::MemoryDatabase;
 use bdk::keys::{DerivableKey, ExtendedKey, GeneratableKey, bip39::Mnemonic};
-use bdk::wallet::{Wallet, AddressIndex};
+use bdk::wallet::{AddressIndex, Wallet};
 use nanoid::nanoid;
-use tracing::info;
 use serde::Serialize;
+use tracing::info;
 
 #[derive(Clone)]
 pub struct AppState {

--- a/server/src/handler/wallet_handler.rs
+++ b/server/src/handler/wallet_handler.rs
@@ -1,11 +1,24 @@
-use crate::model::wallet_model::{WalletRequest, WalletResponse};
+use crate::model::wallet_model::{WalletRequest, WalletResponse, WalletStore};
 use axum::Json;
+use axum::response::IntoResponse;
+use axum::extract::{State, Path};
 use bdk::bitcoin::Network;
 use bdk::database::MemoryDatabase;
 use bdk::keys::{DerivableKey, ExtendedKey, GeneratableKey, bip39::Mnemonic};
-use bdk::wallet::Wallet;
+use bdk::wallet::{Wallet, AddressIndex};
 use nanoid::nanoid;
 use tracing::info;
+use serde::Serialize;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub wallet_store: WalletStore,
+}
+
+#[derive(Serialize)]
+pub struct AddressResponse {
+    pub address: String,
+}
 
 pub async fn create_wallet_handler(Json(req): Json<WalletRequest>) -> Json<WalletResponse> {
     let (mnemonic, is_new) = match req.mnemonic {
@@ -51,4 +64,21 @@ pub async fn create_wallet_handler(Json(req): Json<WalletRequest>) -> Json<Walle
             None
         },
     })
+}
+
+pub async fn get_new_address(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    let store = state.wallet_store.lock().unwrap();
+
+    let wallet = match store.get(&id) {
+        Some(w) => w,
+        None => return Err((axum::http::StatusCode::NOT_FOUND, "Wallet not found")),
+    };
+
+    let address = wallet.get_address(AddressIndex::New).unwrap();
+    Ok(Json(AddressResponse {
+        address: address.to_string(),
+    }))
 }

--- a/server/src/model/wallet_model.rs
+++ b/server/src/model/wallet_model.rs
@@ -1,4 +1,7 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use bdk::{Wallet, database::MemoryDatabase};
 
 #[derive(Deserialize)]
 pub struct WalletRequest {
@@ -11,3 +14,5 @@ pub struct WalletResponse {
     pub descriptor: String,
     pub mnemonic: Option<String>,
 }
+
+pub type WalletStore = Arc<Mutex<HashMap<String, Wallet<MemoryDatabase>>>>;

--- a/server/src/model/wallet_model.rs
+++ b/server/src/model/wallet_model.rs
@@ -1,7 +1,7 @@
+use bdk::{Wallet, database::MemoryDatabase};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use bdk::{Wallet, database::MemoryDatabase};
 
 #[derive(Deserialize)]
 pub struct WalletRequest {

--- a/server/src/routes/wallet_route.rs
+++ b/server/src/routes/wallet_route.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 pub fn wallet_router() -> Router {
     Router::new()
     .route("/wallets", post(create_wallet_handler))
-    .route("x", get(get_new_address))
+    .route("/wallets/:ids/address", get(get_new_address))
     .with_state(AppState {
         wallet_store: Arc::new(Mutex::new(HashMap::new())),
 })

--- a/server/src/routes/wallet_route.rs
+++ b/server/src/routes/wallet_route.rs
@@ -1,6 +1,15 @@
-use crate::handler::wallet_handler::create_wallet_handler;
-use axum::{Router, routing::post};
+use crate::handler::wallet_handler::{create_wallet_handler, get_new_address};
+use crate::handler::wallet_handler::AppState;
+use axum::{Router, routing::{post, get}};
+use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+
 
 pub fn wallet_router() -> Router {
-    Router::new().route("/wallets", post(create_wallet_handler))
+    Router::new()
+    .route("/wallets", post(create_wallet_handler))
+    .route("x", get(get_new_address))
+    .with_state(AppState {
+        wallet_store: Arc::new(Mutex::new(HashMap::new())),
+})
 }

--- a/server/src/routes/wallet_route.rs
+++ b/server/src/routes/wallet_route.rs
@@ -1,15 +1,17 @@
-use crate::handler::wallet_handler::{create_wallet_handler, get_new_address};
 use crate::handler::wallet_handler::AppState;
-use axum::{Router, routing::{post, get}};
-use std::sync::{Arc, Mutex};
+use crate::handler::wallet_handler::{create_wallet_handler, get_new_address};
+use axum::{
+    Router,
+    routing::{get, post},
+};
 use std::collections::HashMap;
-
+use std::sync::{Arc, Mutex};
 
 pub fn wallet_router() -> Router {
     Router::new()
-    .route("/wallets", post(create_wallet_handler))
-    .route("/wallets/:ids/address", get(get_new_address))
-    .with_state(AppState {
-        wallet_store: Arc::new(Mutex::new(HashMap::new())),
-})
+        .route("/wallets", post(create_wallet_handler))
+        .route("/wallets/:ids/address", get(get_new_address))
+        .with_state(AppState {
+            wallet_store: Arc::new(Mutex::new(HashMap::new())),
+        })
 }


### PR DESCRIPTION
# 🚀 Feature: Generate New Bitcoin Receiving Address
This PR adds support for generating a fresh receiving Bitcoin address for a wallet using BDK.

## ✅ What's Implemented
Endpoint: GET /wallets/:id/address

### Functionality:

- Fetches the in-memory wallet by id

- Uses wallet.get_address(AddressIndex::New) to generate a new receiving address

- Returns the address in JSON format

###  🧱 Dependencies
Requires wallet creation via POST /wallets (Issue #2) to have been completed and stored.

### 📌 Notes
This implementation assumes the wallet store is kept in memory; future work may persist this state.

closes #3 